### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-#Deprecated
+# Deprecated
 
-##Library to help developers it integrate (Google Sign-in) and (Facebook Sign-in)
+## Library to help developers it integrate (Google Sign-in) and (Facebook Sign-in)
 
 [![Android Arsenal]( https://img.shields.io/badge/Android%20Arsenal-SimpleLoginLibrary-green.svg?style=true)](https://android-arsenal.com/details/1/3177 ) 
 
@@ -170,7 +170,7 @@ classpath 'com.google.gms:google-services:2.0.0-alpha5' // requisite of Google S
   
 ```
 
-#The MIT License (MIT)
+# The MIT License (MIT)
 Copyright (c) 2016
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
